### PR TITLE
Unit testing 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "An engine for courtbot-like functionality to be included in city/county services sites.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
+    "test": "mocha && npm run lint",
     "test-watch": "mocha --watch",
     "build": "rm -rf lib && babel --presets es2015 src --out-dir lib",
-    "release": "npm run test && npm run build && npm run lint && release && npm publish",
+    "release": "npm run test && npm run build && release && npm publish",
     "lint": "eslint src/ test/ --ext .js, .jsx --ignore-path .eslintignore"
   },
   "keywords": [

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -104,6 +104,7 @@ export function scrubObject(passedObject) {
 
   Object.keys(obj).forEach((key) => {
     if (typeof obj[key] === `string` || typeof obj[key] === `boolean` || typeof obj[key] === `number` || typeof obj[key] === `symbol`) {
+      return;
     }
     else if (Array.isArray(obj[key])) {
       obj[key] = scrubArray(obj[key]);

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -1,6 +1,125 @@
-export default function (options) {
+/* This function returns an options object with at least a default dbURL property
+
+   options: an value which contains additional options
+   if options is an object, it assigns the key/value pairs to the returned object
+   if options is an array, it assigns the values of the array to the string keys corresponding to array index
+       (e.g. The item at array index 0 is assigned to key `0`)
+   if options is a primitive value, it converts the value to an array of length 1, then continues
+
+   if more than one argument is passed, it parses the parameters as above. Arrays are concatenated, and key
+   collisions for multiple objects are resolved by overwriting the existing value of the key.
+
+   WARNING: THIS FUNCTION DOES NOT DEEP COPY OBJECTS/ARRAYS
+   WARNING: THIS FUNCTION REMOVES NESTED ARRAYS AND OBJECTS FROM PARAMETERS
+*/
+
+/* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+   Object.assign() should wrap primitives into the target object, starting with key "0"
+   Does not appear to be happening here, so writing workaround */
+export default function (...args) {
+  let _optionArray = [];
+  let _optionObject = {};
+  
+  // Parse arguments
+  args.forEach((arg) => {
+    // convert primitives
+    if (typeof arg === `string` || typeof arg === `boolean` || typeof arg === `number`) {
+      _optionArray.push(arg)
+    }
+    // Add arrays
+    else if (Array.isArray(arg)) {
+      _optionArray = _optionArray.concat(scrubArray(arg));
+    }
+    // merge additional objects, overwriting existing keys
+    else if (Object.prototype.toString.call(arg) === '[object Object]') {
+      Object.assign(_optionObject, scrubObject(arg));
+    }
+    // treat Symbols and other types as empty objects
+    // The other typeof responses: hostobject, functions and undefined, could cause problems
+    else {
+    }
+  });
+
+  // merge _optionArray into _optionObject
+  Object.assign(_optionObject, _optionArray);  
+
   return Object.assign({
     path: "/courtbot", //deprecated
     dbUrl: process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/courtbotdb"
-  }, options);
+  }, _optionObject);
+}
+
+/* This function removes symbols and functions from an array, mainly to avoid some super hacker
+   pushing functions that interact in unexpected ways with code farther down the line.
+
+   This function returns: false if not passed an array
+                          the array itself if passed an empty array
+                          an array scrubbed of symbols, functions, null and undefined
+*/
+export function scrubArray(passedArray) {
+  if (!Array.isArray(passedArray)) return false;
+
+  // avoid changing passed array
+  let arr = passedArray;
+  if (arr.length === 0) return arr;
+
+  let i = 0;
+  while (i < arr.length) {
+    if (typeof arr[i] === `string` || typeof arr[i] === `boolean` || typeof arr[i] === `number`) {
+      i++;
+    }
+    else if (Array.isArray(arr[i])) {
+      arr[i] = scrubArray(arr[i]);
+      i++;
+    }
+    else if (Object.prototype.toString.call(arr[i]) === `[object Object]`) {
+      arr[i] = scrubObject(arr[i]);
+      i++;
+    }
+    else {
+      arr.splice(i, 1);
+    }
+  }
+
+  return arr;
+}
+
+/* This function removes symbols and functions from the enumerable keys of an object, mainly to
+   avoid some super hacker pushing functions that interact in unexpected ways with code farther
+   down the line.
+
+   This function returns: false if not passed an [object Object] && !null && !undefined
+                          an empty object if passed an empty object
+                          an object scrubbed of symbols, functions, null and undefined
+   
+    */
+export function scrubObject(passedObject) {
+  if (Object.prototype.toString.call(passedObject) !== `[object Object]`) return false;
+  if (passedObject === null || passedObject === undefined) return false;
+
+  // avoid changing passed object while we alter it
+  let obj = {};
+
+  // Scrub all non-enumerable properties, but keep properties farther up the prototype chain.
+  // Also, by assigning the properties over, this scrubs constructor information as well as
+  // makes all property writeable and configurable.
+  for (let key in passedObject) {
+    obj[key] = passedObject[key];
+  }
+
+  Object.keys(obj).forEach((key) => {
+    if (typeof obj[key] === `string` || typeof obj[key] === `boolean` || typeof obj[key] === `number`) {
+    }
+    else if (Array.isArray(obj[key])) {
+      obj[key] = scrubArray(obj[key]);
+    }
+    else if (Object.prototype.toString.call(obj[key]) === `[object Object]`) {
+      obj[key] = scrubObject(obj[key]);
+    }
+    else {
+      delete obj[key];
+    }
+  });
+
+  return obj;
 }

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -36,10 +36,8 @@ export default function (...args) {
     else if (Object.prototype.toString.call(arg) === '[object Object]') {
       Object.assign(_optionObject, scrubObject(arg));
     }
-    // treat other types as empty objects
+    // ignore everything else
     // The other typeof responses: hostobject, functions and undefined, could cause problems
-    else {
-    }
   });
 
   // merge _optionArray into _optionObject
@@ -57,30 +55,26 @@ export default function (...args) {
    hacker including functions that interact in unexpected ways with code farther down the line.
 
    This function returns: false if not passed an array
-                          the array itself if passed an empty array
+                          an empty array if passed an empty array
                           an array scrubbed of functions, null and undefined
 */
-export function scrubArray(arr) {
-  if (!Array.isArray(arr)) return false;
-  if (arr.length === 0) return [];
+export function scrubArray(passedArray) {
+  if (!Array.isArray(passedArray)) return false;
+  if (passedArray.length === 0) return [];
 
-  let i = 0;
-  while (i < arr.length) {
-    if (typeof arr[i] === `string` || typeof arr[i] === `boolean` || typeof arr[i] === `number` || typeof arr[i] === `symbol`) {
-      i++;
+  let arr = [];
+
+  passedArray.forEach((elem) => {
+    if (typeof elem === `string` || typeof elem === `boolean` || typeof elem === `number` || typeof elem === `symbol`) {
+      arr.push(elem);
     }
-    else if (Array.isArray(arr[i])) {
-      arr[i] = scrubArray(arr[i]);
-      i++;
+    else if (Array.isArray(elem)) {
+      arr.push(scrubArray(elem));
     }
-    else if (Object.prototype.toString.call(arr[i]) === `[object Object]`) {
-      arr[i] = scrubObject(arr[i]);
-      i++;
-    }
-    else {
-      arr.splice(i, 1);
-    }
-  }
+    else if (Object.prototype.toString.call(elem) === `[object Object]`) {
+      arr.push(scrubObject(elem));
+    } // ignore everything else
+  });
 
   return arr;
 }

--- a/src/events.js
+++ b/src/events.js
@@ -1,10 +1,13 @@
 const EventEmitter = require(`events`);
 import courtbotError from '../src/courtbotError'
+import log4js from 'log4js';
 import {COURTBOT_ERROR_NAME} from '../src/courtbotError';
 
 class CourtbotEmitter extends EventEmitter {}
 
 const emitter = new CourtbotEmitter();
+
+const logger = log4js.getLogger()
 
 export default emitter;
 
@@ -36,8 +39,8 @@ export function getCaseParties(casenumber, errorMode = 1) {
     })
     .catch((err) => {
       // Raw logging - just to console, not log4js to keep dependencies low
-      console.warn(`events.js getCaseParties() data retrieval raw error on ` + Date() + `:`);
-      console.warn(err);
+      logger.warn(`events.js getCaseParties() data retrieval raw error on ` + Date() + `:`);
+      logger.warn(err);
 
       // Wrap the errors if necessary
       if (err.name !== COURTBOT_ERROR_NAME) {
@@ -99,8 +102,8 @@ export function getCasePartyEvents(casenumber, party, errorMode = 1) {
     })
     .catch((err) => {
       // Raw logging - just to console, not log4js to keep dependencies low
-      console.warn(`events.js getCasePartyEvents() data retrieval raw error on ` + Date() + `:`);
-      console.warn(err);
+      logger.warn(`events.js getCasePartyEvents() data retrieval raw error on ` + Date() + `:`);
+      logger.warn(err);
 
       // Wrap the errors if necessary
       if (err.name !== COURTBOT_ERROR_NAME) {

--- a/src/events.js
+++ b/src/events.js
@@ -1,10 +1,6 @@
-
-import log4js from "log4js";
 const EventEmitter = require(`events`);
 import courtbotError from '../src/courtbotError'
 import {COURTBOT_ERROR_NAME} from '../src/courtbotError';
-
-const logger = log4js.getLogger("events");
 
 class CourtbotEmitter extends EventEmitter {}
 
@@ -23,7 +19,7 @@ export function getCaseParties(casenumber, errorMode = 1) {
   }
 
   // emit runs synchronously because I/O is not involved, so result will always be populated
-  // before Promise.all() is called.
+  // before further functions are called.
   emitter.emit(`retrieve-parties`, casenumber, result);
 
   let results = [];
@@ -59,6 +55,7 @@ export function getCaseParties(casenumber, errorMode = 1) {
   .then(() => {
     // Emit the retrieve-parties-error first. Like retrieve-parties, it runs synchronously because there's no I/O
     if (errorMode % 2) emitter.emit(`retrieve-parties-error`, errors);
+
     // Add the errors to the return value if dictated by errorMode
     if ((errorMode >> 1) % 2) {
       results = {
@@ -82,7 +79,7 @@ export function getCasePartyEvents(casenumber, party, errorMode = 1) {
   }
 
   // emit runs synchronously because I/O is not involved, so result will always be populated
-  // before Promise.all() is called.
+  // before further functions are called.
   emitter.emit("retrieve-party-events", casenumber, party, result);
 
   let results = [];
@@ -122,6 +119,7 @@ export function getCasePartyEvents(casenumber, party, errorMode = 1) {
   .then(() => {
     // Emit the retrieve-parties-error first. Like retrieve-parties, it runs synchronously because there's no I/O
     if (errorMode % 2) emitter.emit(`retrieve-party-events-error`, errors);
+
     // Add the errors to the return value if dictated by errorMode
     if ((errorMode >> 1) % 2) {
       results = {

--- a/src/sources.js
+++ b/src/sources.js
@@ -1,6 +1,10 @@
 
-export var registrationSourceFn = function() { console.warn(`registrationSourceFn in sources.js not initialized`) };
-export var messageSourceFn = function() { console.warn(`messageSourceFn in sources.js not initialized`) };
+import log4js from 'log4js';
+
+const logger = log4js.getLogger();
+
+export var registrationSourceFn = function() { logger.warn(`registrationSourceFn in sources.js not initialized`) };
+export var messageSourceFn = function() { logger.warn(`messageSourceFn in sources.js not initialized`) };
 
 export function setRegistrationSource(sourceFn) {
   // Unlike vanilla JavaScript, node returns `function` when using typeof on functions

--- a/test/courtbotError.test.js
+++ b/test/courtbotError.test.js
@@ -9,13 +9,13 @@ describe(`courtbotError`, () => {
         testee = require(`../src/courtbotError`);
     });
 
-    it (`a courtbotError should extend Error`, () => {
+    it(`a courtbotError should extend Error`, () => {
         let testError = new testee.default();
 
         expect(testError instanceof Error).to.equal(true);
     });
 
-    it (`a courtbotError should have the correct default settings`, () => {
+    it(`a courtbotError should have the correct default settings`, () => {
         let testSettings = {
             type: `general`,
             message: `No message listed`,
@@ -35,7 +35,7 @@ describe(`courtbotError`, () => {
         expect(testError.initialError).to.deep.equal(testSettings.initialError);
     });
 
-    it (`a courtbotError settings should be set correctly`, () => {
+    it(`courtbotError settings should be set correctly`, () => {
         let testSettings = {
             type: `test`,
             message: `message`,
@@ -55,7 +55,7 @@ describe(`courtbotError`, () => {
         expect(testError.initialError).to.deep.equal(testSettings.initialError);          
     });
 
-    it (`a courtbotError should be throwable and identify itself as a courtbotError`, () => {           
+    it(`a courtbotError should be throwable and identify itself as a courtbotError`, () => {           
         try {
             throw(new testee.default());
         }
@@ -64,7 +64,7 @@ describe(`courtbotError`, () => {
         }
     });
 
-    it (`a courtbotError should not include itself in a stack trace by default`, function stackTraceTest() {
+    it(`a courtbotError should not include itself in a stack trace by default`, function stackTraceTest() {
             try {
             throw(new testee.default());
         }
@@ -73,7 +73,7 @@ describe(`courtbotError`, () => {
         }
     });
 
-    it (`a courtbotError should allow frames farther up the trace to be hidden`, function stackTraceTest() {
+    it(`a courtbotError should allow frames farther up the trace to be hidden`, function stackTraceTest() {
         try {
             throw(new testee.default({}, stackTraceTest));
         }

--- a/test/courtbotError.test.js
+++ b/test/courtbotError.test.js
@@ -42,7 +42,7 @@ describe(`courtbotError`, () => {
             case: `case`,
             api: `api`,
             timestamp: Date(),
-            initialError: null
+            initialError: `a`
         }
 
         let testError = new testee.default(testSettings);

--- a/test/courtbotError.test.js
+++ b/test/courtbotError.test.js
@@ -1,7 +1,7 @@
 import setup from './setup';
 
 describe(`courtbotError`, () => {
-    const {sandbox, expect} = setup();
+    const {expect} = setup();
 
     let testee;
 

--- a/test/defaultOptions.test.js
+++ b/test/defaultOptions.test.js
@@ -1,0 +1,364 @@
+import setup from './setup';
+
+describe(`defaultOptions`, () => {
+    const {sandbox, expect} = setup();
+
+    let testee;
+    let noop;
+
+    beforeEach(() => {
+        noop = () => {}
+
+        // Note: The module exports a default, anonymous function that returns an object
+        testee = require(`../src/defaultOptions`);
+    });
+
+    describe(`scrubbers`, () => {
+        it(`scrubArray() should return false when passed a non-array`, () => {
+            expect(testee.scrubArray(undefined)).to.equal(false);
+            expect(testee.scrubArray(null)).to.equal(false);
+            expect(testee.scrubArray(true)).to.equal(false);
+            expect(testee.scrubArray(2)).to.equal(false);
+            expect(testee.scrubArray(NaN)).to.equal(false);
+            expect(testee.scrubArray(`not a function`)).to.equal(false);
+            expect(testee.scrubArray(Symbol(`foo`))).to.equal(false);
+            expect(testee.scrubArray({key: `value`})).to.equal(false);
+            expect(testee.scrubArray(noop)).to.equal(false);
+        });
+
+        it(`scrubArray() should return an empty array when passed an empty-array`, () => {
+            expect(testee.scrubArray([])).to.deep.equal([]);
+        });
+
+        it(`scrubArray() should remove everything but strings, booleans, numbers, and non-function objects from a passed array`, () => {
+            let input = [noop, 5, Symbol(`foo`), true, {}, null, undefined, `string`];
+            let output = [5, true, {}, `string`];
+
+            expect(testee.scrubArray(input)).to.deep.equal(output);
+        });
+
+        it(`scrubArray() should scrub nested arrays`, () => {
+            let input = [5, [noop, 5, Symbol(`foo`), true, {}, null, undefined, `string`], `string`, [1, [undefined, `string`, noop]]];
+            let output = [5, [5, true, {}, `string`], `string`, [1, [`string`]]];
+
+            expect(testee.scrubArray(input)).to.deep.equal(output);
+        });
+
+        it(`scrubObject should return false when passed a non-object, Array or function`, () => {
+            expect(testee.scrubObject(undefined)).to.equal(false);
+            expect(testee.scrubObject(null)).to.equal(false);
+            expect(testee.scrubObject(true)).to.equal(false);
+            expect(testee.scrubObject(2)).to.equal(false);
+            expect(testee.scrubObject(NaN)).to.equal(false);
+            expect(testee.scrubObject(`not a function`)).to.equal(false);
+            expect(testee.scrubObject(Symbol(`foo`))).to.equal(false);
+            expect(testee.scrubObject([])).to.equal(false);
+            expect(testee.scrubObject(noop)).to.equal(false);
+        });
+
+        it(`scrubObject should return an empty object when passed an empty object`, () => {
+            expect(testee.scrubObject({})).to.deep.equal({});
+        });
+
+        it(`scrubObject should return an object scrubbed of everything but string, booleans, numbers and non-function objects`, () => {
+            let input = {
+                a: noop,
+                b: 5,
+                c: Symbol(`foo`),
+                d: true,
+                e: {},
+                f: null,
+                g: undefined,
+            }
+
+            Object.defineProperty(input, `h`, {
+                enumerable: true,
+                configurable: true,
+                get: function() {
+                    return `string`;
+                }
+            });
+
+            Object.defineProperty(input, `noenum`, {
+                enumerable: false,
+                configurable: true,
+                writable: true,
+                value: `not enum`
+            });
+
+            Object.defineProperty(input, `test1`, {
+                enumerable: true,
+                configurable: false,
+                writable: false,
+                value: () => {}
+            });
+
+            let output = {
+                b: 5,
+                d: true,
+                e: {},
+                h: `string`
+            }
+
+            expect(testee.scrubObject(input)).to.deep.equal(output);
+        });
+
+        it(`scrubObject should scrub nested objects`, () => {
+            let input = {
+                a: noop,
+                b: 5,
+                c: Symbol(`foo`),
+                d: true,
+                e: {},
+                f: null,
+                g: undefined,
+                h: `string`,
+                o1: {
+                    a: noop,
+                    b: 5
+                },
+                o2: {
+                    a: Symbol(`bar`),
+                    b: undefined,
+                    hello: `world`
+                }
+            }
+
+            let output = {
+                b: 5,
+                d: true,
+                e: {},
+                h: `string`,
+                o1: {
+                    b: 5
+                },
+                o2: {
+                    hello: `world`
+                }                
+            }
+
+            expect(testee.scrubObject(input)).to.deep.equal(output);
+        });
+
+        // Now combine the two
+        it('scrubArray() should scrub objects nested in arrays', () => {
+            let input = [{a: noop }];
+            let output = [{}];
+            expect(testee.scrubArray(input)).to.deep.equal(output);
+        });
+
+        it (`scrubObject() should scrub arrays nested in objects`, () => {
+            let input = {
+                a: [noop, 5]
+            }
+            let output = {
+                a: [5]
+            }
+            expect(testee.scrubObject(input)).to.deep.equal(output);
+        });
+    });
+
+    describe(`default`, () => {
+        it(`should return an object by default`, () => {
+            expect(testee.default()).to.be.an(`object`);
+        });
+
+        it(`should return an object with at least the dbUrl property`, () => {
+            expect(testee.default()).to.contain.keys(`dbUrl`);
+        });
+
+        it('should return an object that contains the same key/value pairs as a passed object', () => {
+            let o = { key: `value`, foo: `bar` }
+
+            let keys = Object.keys(o);
+            let options = testee.default(o);
+
+            expect(options).to.include.keys(keys);
+            keys.forEach((key) => {
+                expect(options[key]).to.equal(o[key]);
+            });
+        });
+
+        it('should assign each element of a passed array to the object to the string key corresponding to array index', () => {
+            let o = [`option`, `option2`, `option3`, `kablam!`];
+            let options = testee.default(o);
+
+            for (let i in o) {
+                expect(options[i]).to.equal(o[i]);
+            }
+        });
+
+        it (`should scrub null, undefined, Symbol and function elements in an array from the array`, () => {
+            let o1 = [`option`, null, `option2`, undefined, `option3`, Symbol(`foo`), noop,`kablam!`];
+            let o2 = [`option`, `option2`, `option3`, `kablam!`];
+            let options = testee.default(o1);
+
+            for (let i in o2) {
+                expect(options[i]).to.equal(o2[i]);           
+            }
+        });
+
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign,
+        // Object.assign() should wrap numbers, booleans and strings into the target object, starting with key "0"
+        it('should wrap primitives into the object with key "0"', () => {
+            expect(testee.default(5)[`0`]).to.equal(5);
+            expect(testee.default(true)[`0`]).to.equal(true);
+            expect(Number.isNaN(testee.default(NaN)[`0`])).to.be.ok;
+            expect(testee.default(`not a function`)[0]).to.equal(`not a function`);
+        });
+
+        it('should ignore functions, Symbols, null and undefined being passed', () => {
+            expect(testee.default(Symbol(`foo`))).to.not.include.keys(`0`);
+            expect(testee.default(noop)).to.not.include.keys(`0`);
+            expect(testee.default(null)).to.not.include.keys(`0`);
+            expect(testee.default(undefined)).to.not.include.keys(`0`);
+        });
+
+        it(`should not assign each character of a passed string to a different property of the returned object`, () => {
+            let test = `not an object`;
+
+            expect(testee.default(test)).to.not.include.keys((test.length - 1) + ``);
+        });
+
+        it(`should wrap multiple objects being passed into the returned object`, () => {
+            let o1 = { key: `value`}
+            let o2 = { foo: `bar` }
+
+            let o1keys = Object.keys(o1);
+            let o2keys = Object.keys(o2);
+            let options = testee.default(o1, o2);
+
+            o1keys.forEach((key) => {
+                expect(options[key]).to.equal(o1[key]);
+            });
+
+            o2keys.forEach((key) => {
+                expect(options[key]).to.equal(o2[key]);
+            });
+        });
+
+        it(`should overwrite the values for existing keys when passed multiple objects`, () => {
+            let o1 = { key: `value`, foo: `bar` }
+            let o2 = { key: `foo` }
+
+            let options = testee.default(o1, o2);
+            expect(options.key).to.equal(o2.key);
+            expect(options.foo).to.equal(o1.foo);
+
+            options = testee.default(o2, o1);
+            expect(options.key).to.equal(o1.key);
+            expect(options.foo).to.equal(o1.foo);
+        });
+
+        it(`should have all values when passed both an object and an array`, () => {
+            let o1 = { key: `value`, foo: `bar` }
+            let o2 = [`option`, `option2`, `option3`, `kablam!`];
+
+            let options = testee.default(o1, o2);
+
+            Object.keys(o1).forEach((key) => {
+                expect(options[key]).to.equal(o1[key]);
+            });
+            Object.keys(o2).forEach((key) => {
+                expect(options[key]).to.equal(o2[key]);
+            });
+        });
+
+        it(`should have all values when passed an object and primitives`, () => {
+            let o = { key: `value`, foo: `bar` }
+
+            let options = testee.default(o, true, 5);
+
+            Object.keys(o).forEach((key) => {
+                expect(options[key]).to.equal(o[key]);
+            });
+            expect(options[`0`]).to.equal(true);
+            expect(options[`1`]).to.equal(5);
+        })
+
+        it('should have all values when an array has multiple acceptable primitives', () => {
+            let o = [1, `not a function`, true, NaN];
+            let options = testee.default(...o);
+
+            Object.keys(o).forEach((key) => {
+                if (Number.isNaN(o[key])) {
+                    expect(Number.isNaN(options[key])).to.be.ok;
+                }
+                else {
+                    expect(options[key]).to.equal(o[key]);
+                }
+            });
+        });
+
+        it(`should ignore functions, symbols, null and undefined when passed multiple primitives`, () => {
+            let o1 = [1, null, `not a function`, undefined, true, noop, NaN, Symbol(`foo`)];
+            let o2 = [1, `not a function`, true, NaN];
+            let options = testee.default(...o1);
+
+            Object.keys(o2).forEach((key) => {
+                if (Number.isNaN(o2[key])) {
+                    expect(Number.isNaN(options[key])).to.be.ok;
+                }
+                else {
+                    expect(options[key]).to.equal(o2[key]);
+                }
+            });
+        });
+
+        it(`should concatenate accordingly when passed multiple arrays`, () => {
+            let input1 = [5];
+            let input2 = [4];
+            let output = [5, 4];
+
+            let options = testee.default(input1, input2);
+            Object.keys(output).forEach((key) => {
+                expect(options[key]).to.equal(output[key]);
+            });
+
+            options = testee.default(input2, input1);
+            output.reverse();
+            Object.keys(output).forEach((key) => {
+                expect(options[key]).to.equal(output[key]);
+            });
+        });
+
+        it (`should concatenate accordingly when passed an array and primitives`, () => {
+            let input1 = [5, 3, 2];
+            let input2 = [true, true, false];
+            let output = [5, 3, 2, true, true, false];
+
+            let options = testee.default(input1, ...input2);
+            Object.keys(output).forEach((key) => {
+                expect(options[key]).to.equal(output[key]);
+            });
+
+            options = testee.default(...input1, input2);
+            Object.keys(output).forEach((key) => {
+                expect(options[key]).to.equal(output[key]);
+            });
+        });
+
+        it (`should have all values and concatenate accordingly when passed an object, array and primitives`, () => {
+            let input1 = { key: `value`, foo: `bar` }
+            let input2 = [5, 3, 2];
+            let input3 = [true, true, false];
+            let output = [5, 3, 2, true, true, false];
+
+            let options = testee.default(input1, input2, ...input3);
+            Object.keys(input1).forEach((key) => {
+                expect(options[key]).to.equal(input1[key]);
+            });
+            Object.keys(output).forEach((key) => {
+                expect(options[key]).to.equal(output[key]);
+            });
+
+            options = testee.default(...input2, input1, input3);
+            Object.keys(input1).forEach((key) => {
+                expect(options[key]).to.equal(input1[key]);
+            });
+            Object.keys(output).forEach((key) => {
+                expect(options[key]).to.equal(output[key]);
+            });
+        });
+    });
+});

--- a/test/defaultOptions.test.js
+++ b/test/defaultOptions.test.js
@@ -1,7 +1,7 @@
 import setup from './setup';
 
 describe(`defaultOptions`, () => {
-    const {sandbox, expect} = setup();
+    const {expect} = setup();
 
     let testee;
     let noop;

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -18,7 +18,6 @@ describe(`events`, () => {
     let successfulPromise;
     let failedPromise;
 
-    let retrieveStub;
     let retrieveErrorStub;
     let emptyResult;
 
@@ -34,7 +33,6 @@ describe(`events`, () => {
         dummyEventList = [{date: `1`}, [{date: '2'}, {date: `3`}]];
         reducedDummyEventList = [{date: `1`}, {date: '2'}, {date: `3`}];
 
-        retrieveStub = sandbox.stub();
         retrieveErrorStub = sandbox.stub();
         emptyResult = { promises: [] };
 
@@ -58,24 +56,14 @@ describe(`events`, () => {
     
     describe(`getCaseParties()`, () => {
         it(`the emitter should emit the retrieve-parties event`, () => {
-            emitter.on(`retrieve-parties`, retrieveStub);
-
-            return testee.getCaseParties(dummyCase)
-                .then(() => {
-                    expect(retrieveStub).to.have.been.called();
-                });
+            return expect(testee.getCaseParties).to.emitFrom(emitter, `retrieve-parties`);
         });
 
         it(`should pass the casenumber and the empty result object to the event listener`, () => {
-            emitter.on(`retrieve-parties`, retrieveStub);
-
-            return testee.getCaseParties(dummyCase)
-                .then(() => {
-                    expect(retrieveStub).to.have.been.calledWith(dummyCase, emptyResult);
-                });
+            return expect(() => {testee.getCaseParties(dummyCase)}).to.emitFrom(emitter, `retrieve-parties`, dummyCase, emptyResult);
         });
 
-        it (`if no errors in data retrieval, should return a concatenated array of all party names found`, () => {
+        it(`if no errors in data retrieval, should return a concatenated array of all party names found`, () => {
             emitter.on(`retrieve-parties`, (casenumber, result) => {
                 dummyPartyList.forEach((elem) => {
                     result.promises.push(successfulPromise(elem));
@@ -85,7 +73,13 @@ describe(`events`, () => {
             return testee.getCaseParties(dummyCase).should.eventually.deep.equal(reducedDummyPartyList);
         });
 
-        it (`if there are errors in data retrieval, should return only a concatenated array of all parties found by default`, () => {
+/*        it(`should only return unique parties if duplicate parties are found`, () => {
+            emitter.on(`retrieve-parties`, (casenumber, result) => {
+
+            })
+        }); */
+
+        it(`if there are errors in data retrieval, should return only a concatenated array of all parties found by default`, () => {
             emitter.on(`retrieve-parties`, (casenumber, result) => {
                 dummyPartyList.forEach((elem) => {
                     result.promises.push(successfulPromise(elem));
@@ -97,9 +91,7 @@ describe(`events`, () => {
             return testee.getCaseParties(dummyCase).should.eventually.deep.equal(reducedDummyPartyList);
         });
 
-        it (`if there are errors in data retrieval, should emit the retrieve-parties-error event by default`, () => {
-            emitter.on(`retrieve-parties-error`, retrieveErrorStub);
-
+        it(`if there are errors in data retrieval, should emit the retrieve-parties-error event by default`, () => {
             emitter.on(`retrieve-parties`, (casenumber, result) => {
                 dummyPartyList.forEach((elem) => {
                     result.promises.push(successfulPromise(elem));
@@ -110,16 +102,13 @@ describe(`events`, () => {
                 result.promises.push(failedPromise(`3`));
             });
 
-            return testee.getCaseParties(dummyCase)
-                .then(() => {
-                    expect(retrieveErrorStub).to.have.been.called();
-                });
+            return expect(() => { testee.getCaseParties(dummyCase) }).to.emitFrom(emitter, `retrieve-parties`);
         });
 
-        it (`if there are errors in data retrieval, should emit retrieve-parties-error by default with an array of courtbotErrors with at least one error`, () => {
+        it(`if there are errors in data retrieval, should emit retrieve-parties-error by default with an array of courtbotErrors with at least one error`, () => {
             emitter.on(`retrieve-parties-error`, (errors) => {
-                expect(Array.isArray(errors)).to.equal(true);
-                expect(errors.length).to.not.equal(0);
+                expect(errors).to.be.an(`Array`);
+                expect(errors).to.not.be.empty;
                 expect(errors.every((e) => { return e.isCourtbotError === true })).to.equal(true);
             });
 
@@ -136,7 +125,7 @@ describe(`events`, () => {
             return testee.getCaseParties(dummyCase);
         });
 
-        it (`should place the data from non-courtbotError non-objects into courtbotError.initialError.data`, () => {
+        it(`should place the data from non-courtbotError non-objects into courtbotError.initialError.data`, () => {
             let testData = `testing`;
 
             emitter.on(`retrieve-parties-error`, (errors) => {
@@ -154,7 +143,7 @@ describe(`events`, () => {
             return testee.getCaseParties(dummyCase);
         });
 
-        it (`should place the data from non-courtbotError objects into courtbotError.initialError`, () => {
+        it(`should place the data from non-courtbotError objects into courtbotError.initialError`, () => {
             let testData = new Error(`testing`);
 
             emitter.on(`retrieve-parties-error`, (errors) => {
@@ -172,9 +161,8 @@ describe(`events`, () => {
             return testee.getCaseParties(dummyCase);
         });
 
-        it ('should not place anything in intial error if the data error is a courtbotError', () => {
+        it('should not place anything in intial error if the data error is a courtbotError', () => {
             let testData = new courtbotError(``);
-            console.log(testee);
 
             emitter.on(`retrieve-parties-error`, (errors) => {
                 expect(errors[0].initialError).to.deep.equal(null);
@@ -191,9 +179,7 @@ describe(`events`, () => {
             return testee.getCaseParties(dummyCase);            
         });
 
-        it ('should not emit the retrieve-parties-error event if the 1s bit of errorMode is off', () => {
-            emitter.on(`retrieve-parties-error`, retrieveErrorStub);
-
+        it('should not emit the retrieve-parties-error event if the 1s bit of errorMode is off', () => {
             emitter.on(`retrieve-parties`, (casenumber, result) => {
                 dummyPartyList.forEach((elem) => {
                     result.promises.push(successfulPromise(elem));
@@ -202,13 +188,10 @@ describe(`events`, () => {
                 result.promises.push(failedPromise(`1`));
             });
 
-            return testee.getCaseParties(dummyCase, 2)
-                .then(() => {
-                    expect(retrieveErrorStub).to.not.have.been.called();
-                });
+            return expect(() => {testee.getCaseParties(dummyCase, 2)}).to.not.emitFrom(emitter, `retrieve-parties-error`);
         });
 
-        it ('should return a { parties: [], errors: [] } object if the 2s bit of errorMode is on', () => {
+        it('should return a { parties: [], errors: [] } object if the 2s bit of errorMode is on', () => {
             emitter.on(`retrieve-parties`, (casenumber, result) => {
                 dummyPartyList.forEach((elem) => {
                     result.promises.push(successfulPromise(elem));
@@ -227,28 +210,16 @@ describe(`events`, () => {
         });
     });
 
-    describe(`getCasePartyEvents()`, () => {
-
-        
+    describe(`getCasePartyEvents()`, () => {        
         it(`the emitter should emit the retrieve-party-events event`, () => {
-            emitter.on(`retrieve-party-events`, retrieveStub);
-
-            return testee.getCasePartyEvents(dummyCase, dummyParty)
-                .then(() => {
-                    expect(retrieveStub).to.have.been.called();
-                });
+            return expect(testee.getCasePartyEvents).to.emitFrom(emitter, `retrieve-party-events`);
         });
 
         it(`should pass the casenumber, party and the empty result object to the event listener`, () => {
-            emitter.on(`retrieve-party-events`, retrieveStub);
-
-            return testee.getCasePartyEvents(dummyCase, dummyParty)
-                .then(() => {
-                    expect(retrieveStub).to.have.been.calledWith(dummyCase,dummyParty, emptyResult);
-                });
+            return expect(() => {testee.getCasePartyEvents(dummyCase, dummyParty)}).to.emitFrom(emitter, `retrieve-party-events`, dummyCase, dummyParty, emptyResult);
         });
 
-        it (`if no errors in data retrieval, should return a concatenated array of all party names found`, () => {
+        it(`if no errors in data retrieval, should return a concatenated array of all party names found`, () => {
             emitter.on(`retrieve-party-events`, (casenumber, party, result) => {
                 dummyEventList.forEach((elem) => {
                     result.promises.push(successfulPromise(elem));
@@ -258,7 +229,7 @@ describe(`events`, () => {
             return testee.getCasePartyEvents(dummyCase, dummyParty).should.eventually.deep.equal(reducedDummyEventList);
         });
 
-        it (`if there are errors in data retrieval, should return only a concatenated array of all parties found by default`, () => {
+        it(`if there are errors in data retrieval, should return only a concatenated array of all parties found by default`, () => {
             emitter.on(`retrieve-party-events`, (casenumber, party, result) => {
                 dummyEventList.forEach((elem) => {
                     result.promises.push(successfulPromise(elem));
@@ -270,7 +241,7 @@ describe(`events`, () => {
             return testee.getCasePartyEvents(dummyCase).should.eventually.deep.equal(reducedDummyEventList);
         });
 
-        it (`if there are errors in data retrieval, should emit the retrieve-party-events-error event by default`, () => {
+        it(`if there are errors in data retrieval, should emit the retrieve-party-events-error event by default`, () => {
             emitter.on(`retrieve-party-events-error`, retrieveErrorStub);
 
             emitter.on(`retrieve-party-events`, (casenumber, party, result) => {
@@ -283,16 +254,20 @@ describe(`events`, () => {
                 result.promises.push(failedPromise(`3`));
             });
 
+            // This test fails, but should be equivalent to the uncommented test. Will look into it later, but it works for now
+            // No sense wasting time
+            // return expect(() => { testee.getCasePartyEvents(dummyCase, dummyParty) }).to.emitFrom(emitter, `retrieve-party-events-error`);
+
             return testee.getCasePartyEvents(dummyCase, dummyParty)
                 .then(() => {
                     expect(retrieveErrorStub).to.have.been.called();
                 });
         });
 
-        it (`if there are errors in data retrieval, should emit retrieve-party-events-error by default with an array of courtbotErrors with at least one error`, () => {
+        it(`if there are errors in data retrieval, should emit retrieve-party-events-error by default with an array of courtbotErrors with at least one error`, () => {
             emitter.on(`retrieve-party-events-error`, (errors) => {
-                expect(Array.isArray(errors)).to.equal(true);
-                expect(errors.length).to.not.equal(0);
+                expect(errors).to.be.an(`Array`);
+                expect(errors).to.not.be.empty;
                 expect(errors.every((e) => { return e.isCourtbotError === true })).to.equal(true);
             });
 
@@ -309,7 +284,7 @@ describe(`events`, () => {
             return testee.getCasePartyEvents(dummyCase);
         });
 
-        it (`should place the data from non-courtbotError non-objects into courtbotError.initialError.data`, () => {
+        it(`should place the data from non-courtbotError non-objects into courtbotError.initialError.data`, () => {
             let testData = `testing`;
 
             emitter.on(`retrieve-party-events-error`, (errors) => {
@@ -327,7 +302,7 @@ describe(`events`, () => {
             return testee.getCasePartyEvents(dummyCase, dummyParty);
         });
 
-        it (`should place the data from non-courtbotError objects into courtbotError.initialError`, () => {
+        it(`should place the data from non-courtbotError objects into courtbotError.initialError`, () => {
             let testData = new Error(`testing`);
 
             emitter.on(`retrieve-party-events-error`, (errors) => {
@@ -345,7 +320,7 @@ describe(`events`, () => {
             return testee.getCaseParties(dummyCase, dummyParty);
         });
 
-        it ('should not place anything in intial error if the data error is a courtbotError', () => {
+        it('should not place anything in intial error if the data error is a courtbotError', () => {
             let testData = new courtbotError(``);
 
             emitter.on(`retrieve-party-events-error`, (errors) => {
@@ -363,7 +338,7 @@ describe(`events`, () => {
             return testee.getCasePartyEvents(dummyCase, dummyParty);            
         });
 
-        it ('should not emit the retrieve-parties-error event if the 1s bit of errorMode is off', () => {
+        it('should not emit the retrieve-parties-error event if the 1s bit of errorMode is off', () => {
             emitter.on(`retrieve-party-events-error`, retrieveErrorStub);
 
             emitter.on(`retrieve-party-events`, (casenumber, party, result) => {
@@ -380,7 +355,7 @@ describe(`events`, () => {
                 });
         });
 
-        it ('should return a { events: [], errors: [] } object if the 2s bit of errorMode is on', () => {
+        it('should return a { events: [], errors: [] } object if the 2s bit of errorMode is on', () => {
             emitter.on(`retrieve-party-events`, (casenumber, party, result) => {
                 dummyEventList.forEach((elem) => {
                     result.promises.push(successfulPromise(elem));
@@ -398,5 +373,4 @@ describe(`events`, () => {
                 });
         });
     });
-
 });

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -5,7 +5,6 @@ describe(`events`, () => {
     const {sandbox, expect} = setup();
 
     let testee;
-    let testCase;
     let emitter;
 
     let dummyCase;
@@ -23,7 +22,6 @@ describe(`events`, () => {
 
     beforeEach(() => {
         testee = require(`../src/events.js`);
-        testCase = `CF-2016-644`;
         emitter = testee.default;
 
         dummyCase = -1;
@@ -37,7 +35,7 @@ describe(`events`, () => {
         emptyResult = { promises: [] };
 
         successfulPromise = (value) => {           
-            return new Promise ((resolve, reject) => {
+            return new Promise ((resolve) => {
                 resolve(value);
             })
         }

--- a/test/sources.test.js
+++ b/test/sources.test.js
@@ -1,7 +1,7 @@
 import setup from './setup';
 
 describe("sources", () => {
-    const {sandbox, expect} = setup();
+    const {expect} = setup();
 
     let testee;
     let noop;

--- a/test/sources.test.js
+++ b/test/sources.test.js
@@ -12,37 +12,28 @@ describe("sources", () => {
         testee = require(`../src/sources.js`);
     });
 
+    it ("registrationSourceFn should have a default function", () => {
+        expect(typeof testee.registrationSourceFn).to.equal(`function`);
+    });
+
     it("function setRegistrationSource should set registrationSouceFn correctly", () => {
         testee.setRegistrationSource(noop);
         expect(testee.registrationSourceFn).to.equal(noop);
     });
 
-    it("function setRegistrationSource should return an error value when called with a non-function argument", () => {
-        let returnValue;
+    it("function setRegistrationSource should return true when set registrationSouceFn correctly", () => {
+        expect(testee.setRegistrationSource(noop)).to.equal(true);
+    });
 
-        returnValue = testee.setRegistrationSource(undefined);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setRegistrationSource(null);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setRegistrationSource(true);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setRegistrationSource(2);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setRegistrationSource(NaN);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setRegistrationSource(`not a function`);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setRegistrationSource(Symbol(`foo`));
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setRegistrationSource({key: `value`});
-        expect(returnValue).to.not.equal(undefined);
+    it("function setRegistrationSource should return false when called with a non-function argument", () => {
+        expect(testee.setRegistrationSource(undefined)).to.be.not.ok;
+        expect(testee.setRegistrationSource(null)).to.equal(false);
+        expect(testee.setRegistrationSource(true)).to.equal(false);
+        expect(testee.setRegistrationSource(2)).to.equal(false);
+        expect(testee.setRegistrationSource(NaN)).to.equal(false);
+        expect(testee.setRegistrationSource(`not a function`)).to.equal(false);
+        expect(testee.setRegistrationSource(Symbol(`foo`))).to.equal(false);
+        expect(testee.setRegistrationSource({key: `value`})).to.equal(false);
     });
 
     it ("function setRegistrationSource should not override current registrationSourceFn when called with a non-function argument", () => {
@@ -74,7 +65,7 @@ describe("sources", () => {
     });
 
     it ("registrationSourceFn should have a default function", () => {
-        expect(typeof testee.registrationSourceFn).to.equal(`function`);
+        expect(typeof testee.messageSourceFn).to.equal(`function`);
     });
 
     it("function setMessageSource should set messageSourceFn correctly", () => {
@@ -82,32 +73,19 @@ describe("sources", () => {
         expect(testee.messageSourceFn).to.equal(noop);
     });
 
-    it("function setMessageSource should return an error value when called with a non-function argument", () => {
-        let returnValue;
+    it("function setMessageSource should return a truthy value when setting messageSourceFn correctly", () => {
+        expect(testee.setMessageSource(noop)).to.equal(true);
+    });
 
-        returnValue = testee.setMessageSource(undefined);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setMessageSource(null);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setMessageSource(true);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setMessageSource(2);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setMessageSource(NaN);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setMessageSource(`not a function`);
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setMessageSource(Symbol(`foo`));
-        expect(returnValue).to.not.equal(undefined);
-
-        returnValue = testee.setMessageSource({key: `value`});
-        expect(returnValue).to.not.equal(undefined);
+    it("function setMessageSource should return a falsy value when called with a non-function argument", () => {
+        expect(testee.setMessageSource(undefined)).to.equal(false);
+        expect(testee.setMessageSource(null)).to.equal(false);
+        expect(testee.setMessageSource(true)).to.equal(false);
+        expect(testee.setMessageSource(2)).to.equal(false);
+        expect(testee.setMessageSource(NaN)).to.equal(false);
+        expect(testee.setMessageSource(`not a function`)).to.equal(false);
+        expect(testee.setMessageSource(Symbol(`foo`))).to.equal(false);
+        expect(testee.setMessageSource({key: `value`})).to.equal(false);
     });
 
     it ("function setMessageSource should not override current messageSourceFn when called with a non-function argument", () => {
@@ -136,9 +114,5 @@ describe("sources", () => {
 
         testee.setMessageSource({key: `value`});
         expect(testee.messageSourceFn).to.equal(noop);
-    });
-
-    it ("registrationSourceFn should have a default function", () => {
-        expect(typeof testee.messageSourceFn).to.equal(`function`);
     });
 });


### PR DESCRIPTION
* Updated defaultOptions.js to accept multiple options parameters
* Updated defaultOptions.js to mimic specified behavior of `Object.assign()`, which wasn't happening when passed a string
* Updated defaultOptions.js to scrub passed options parameters functions, hostobjects, null and undefined (in line with `Object.assign()` specified behavior)
* Created defaultOptions.test.js to unit test changes
* Updated unit tests to take advantage of chai constructs (thanks for finding chai-emitter!)
* Updated sources.test.js to test for specific return values, instead of the just the presence of them
* Added comments/changed comments, made proofreading changes