### PR TITLE
Pattern matching mergable

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -75,7 +75,7 @@ export function getCaseParties(casenumber, options) {
 
       if(errors.length) {
         logger.error(wrappedErrors);
-        if(emitErrorEvent)  emitter.emit("retrieve-parties-error", wrappedErrors);
+        if(emitErrorEvent) emitter.emit("retrieve-parties-error", wrappedErrors);
       }
 
       if(returnErrorsWithData) {


### PR DESCRIPTION
Part 2 of 2 (as promised)

* Using the newfound power of `CourtbotError.wrap()`...
* ...let's simplify the code!

And also

* make CourtbotError uppercase for good practice
* updated unit tests